### PR TITLE
Nw fix show vendor form

### DIFF
--- a/src/javascripts/components/vendor/newVendorForm.js
+++ b/src/javascripts/components/vendor/newVendorForm.js
@@ -25,7 +25,7 @@ const newVendorForm = () => {
   </form> 
   `;
 
-  utils.printToDom('#add-vendor-form', domString);
+  utils.printToDom('#vendor-form', domString);
 };
 
 export default {


### PR DESCRIPTION
Closes #58.

I previously re-named the id in the form div to be more generic (instead of the previous 'add-vendor-form' id) but did not change it in the call to `printToDom` from within the `newVendorForm` function.  This has been fixed.