### PR TITLE
Nw vendor form container

### DIFF
--- a/src/javascripts/components/vendor/editVendorForm.js
+++ b/src/javascripts/components/vendor/editVendorForm.js
@@ -9,6 +9,7 @@ const showEditVendorForm = (fbVendorId, {
 }) => {
   const domString = `
   <div class="container">
+  <h2>Update Vendor</h2>
   <form class="hide" id="edit-vendor-form">
     <div class="form-group">
       <label for="inputAddress">Address</label>

--- a/src/javascripts/components/vendor/editVendorForm.js
+++ b/src/javascripts/components/vendor/editVendorForm.js
@@ -8,6 +8,7 @@ const showEditVendorForm = (fbVendorId, {
   vendorId,
 }) => {
   const domString = `
+  <div class="container">
   <form class="hide" id="edit-vendor-form">
     <div class="form-group">
       <label for="inputAddress">Address</label>
@@ -29,6 +30,7 @@ const showEditVendorForm = (fbVendorId, {
     </div>
     <button type="submit" class="btn btn-primary" id="submit-update-vendor" data-firebase-vendor-id="${fbVendorId}" data-vendorId="${vendorId}">Update Vendor</button>
   </form> 
+  </div>
   `;
 
   utils.printToDom('#vendor-form', domString);

--- a/src/javascripts/components/vendor/newVendorForm.js
+++ b/src/javascripts/components/vendor/newVendorForm.js
@@ -3,6 +3,7 @@ import utils from '../../helpers/utils';
 const newVendorForm = () => {
   const domString = `
   <div class="container">
+  <h2>New Vendor</h2>
   <form class="hide" id="new-vendor-form">
     <div class="form-group">
       <label for="inputAddress">Address</label>

--- a/src/javascripts/components/vendor/newVendorForm.js
+++ b/src/javascripts/components/vendor/newVendorForm.js
@@ -2,6 +2,7 @@ import utils from '../../helpers/utils';
 
 const newVendorForm = () => {
   const domString = `
+  <div class="container">
   <form class="hide" id="new-vendor-form">
     <div class="form-group">
       <label for="inputAddress">Address</label>
@@ -23,6 +24,7 @@ const newVendorForm = () => {
     </div>
     <button type="submit" class="btn btn-primary" id="submit-new-vendor">Submit New Vendor</button>
   </form> 
+  </div>
   `;
 
   utils.printToDom('#vendor-form', domString);


### PR DESCRIPTION
Closes #63 

Because the vendor form was sized the full width of the screen, this makes the scroll bar appear and disappear making the form seem like it's "wiggling" on the screen due to the small width changes.

I've wrapped the forms in a container div which provides the necessary margin to the forms to stop this behavior.